### PR TITLE
fix: replay query after stream sync

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -238,6 +238,7 @@ async function syncStreamPosts(root = document) {
       const updated = await loadStreamPostsFromDb();
       if (fuse) {
         fuse.setCollection(updated); //元データが増えたら最新の配列に差し替えるAPI
+        rerunLastQuery();
       }
     }
   } finally {
@@ -460,6 +461,8 @@ const options = {
 
 //fuseを作る。
 let fuse;
+// IndexedDB からの読み込みが終わるまでの間に入力されたキーワードを保持する
+let lastQuery = "";
 async function initFuse() {
   try {
     const posts = await loadStreamPostsFromDb();
@@ -473,6 +476,7 @@ async function initFuse() {
 //ユーザーからの入力をfuseのsearchにかけている。返り値は{item,score,refindex,...}
 function onSerchInput(event) {
   const query = event.target.value.trim();
+  lastQuery = query;
   if (!query || !fuse) {
     renderSuggestions([]);
     return;
@@ -523,10 +527,18 @@ function renderSuggestions(items) {
   container.classList.add("has-results");
 }
 
+// IndexedDB からの差分同期後に、最後に入力したクエリで再検索するためのヘルパー
+function rerunLastQuery() {
+  if (!lastQuery || !fuse) return;
+  const results = fuse.search(lastQuery);
+  renderSuggestions(results.map((item) => item.item));
+}
+
 async function init() {
   // 初期化フロー: スタイル注入 → ライブラリ読み込み → UI 注入 → DOM 監視
   ensureTopbar();
   await loadLocalLibs();
+  await syncStreamPosts();
   await initFuse();
   observe();
   console.debug("[GCX] search input injection initialized");


### PR DESCRIPTION
## Summary
- seed the search index by running the stream-to-IndexedDB sync before Fuse initialization
- cache the last query and replay it after Fuse's collection refreshes so suggestions appear once data arrives

## Testing
- not run (extension UI change)

------
https://chatgpt.com/codex/tasks/task_e_68d87b19e4a4832caa67534906335279