### PR TITLE
IndexedDBの保存プロパティ検証スクリプトを追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,21 @@
       "dependencies": {
         "fuse.js": "^6.6.2"
       },
+      "devDependencies": {
+        "fake-indexeddb": "^5.0.2"
+      },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/fake-indexeddb": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-5.0.2.tgz",
+      "integrity": "sha512-cB507r5T3D55DfclY01GLkninZLfU7HXV/mhVRTnTRm5k2u+fY7Fof2dBkr80p5t7G7dlA/G5dI87QiMdPpMCQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/fuse.js": {

--- a/package.json
+++ b/package.json
@@ -11,9 +11,13 @@
     "dev": "echo 'Load extension via chrome://extensions (unpacked)'",
     "build": "echo 'No build step required. Optionally add Vite/Rollup.'",
     "test": "echo 'No tests defined' && exit 0",
-    "lint": "echo 'ESLint not configured yet' && exit 0"
+    "lint": "echo 'ESLint not configured yet' && exit 0",
+    "check:db": "node scripts/validate-indexeddb.mjs"
   },
   "dependencies": {
     "fuse.js": "^6.6.2"
+  },
+  "devDependencies": {
+    "fake-indexeddb": "^5.0.2"
   }
 }

--- a/scripts/validate-indexeddb.mjs
+++ b/scripts/validate-indexeddb.mjs
@@ -1,0 +1,109 @@
+// IndexedDB の中身を Node.js 上で確認するデバッグスクリプト
+// 初心者向けポイント: ブラウザの indexedDB を Node で真似るため fake-indexeddb を使う
+import 'fake-indexeddb/auto';
+
+// まずは content.js が参照する window / document をダミーで用意
+const fakeDocument = {
+  readyState: 'loading',
+  addEventListener: () => {
+    // テスト環境なので何もしない
+  },
+};
+
+const fakeWindow = {
+  dispatchEvent: () => {},
+  addEventListener: () => {},
+  removeEventListener: () => {},
+};
+fakeWindow.document = fakeDocument;
+
+// グローバルに差し込んでから content.js を読み込む
+globalThis.document = fakeDocument;
+globalThis.window = fakeWindow;
+
+await import('../src/content.js');
+
+const debug = globalThis.window.__gcxDebug;
+if (!debug) {
+  throw new Error('デバッグ API の取得に失敗');
+}
+
+// 教師投稿のサンプルデータ（本番と同じ構造）
+const samplePosts = [
+  {
+    index: 1,
+    streamId: 'stream-001',
+    teacherName: '田中先生',
+    postedAt: { text: '2024/05/01 09:00', datetime: '2024-05-01T09:00:00Z' },
+    body: '1 時限目の体育は集合時間が早まります。',
+    attachments: [
+      {
+        type: 'driveFile',
+        driveId: 'drive-doc-001',
+        href: 'https://example.com/doc1',
+        title: '連絡資料.pdf',
+      },
+    ],
+  },
+  {
+    index: 2,
+    streamId: 'stream-002',
+    teacherName: '佐藤先生',
+    postedAt: { text: '2024/05/02 10:30', datetime: '2024-05-02T10:30:00Z' },
+    body: '国語の課題プリントを提出してください。',
+    attachments: [],
+  },
+];
+
+// getNow を固定すると savedAt の検証がしやすい
+const fixedNow = 1_714_540_800_000; // 2024-05-01T00:00:00Z あたり
+
+await debug.persistStreamData(undefined, {
+  presetPosts: samplePosts,
+  getNow: () => fixedNow,
+});
+
+const stored = await debug.loadStreamPostsFromDb();
+
+const requiredKeys = [
+  'index',
+  'streamId',
+  'teacherName',
+  'postedAt',
+  'body',
+  'attachments',
+  'savedAt',
+];
+
+const report = stored.map((record) => {
+  const missing = requiredKeys.filter(
+    (key) => !Object.prototype.hasOwnProperty.call(record, key),
+  );
+  return {
+    streamId: record.streamId,
+    hasAllKeys: missing.length === 0,
+    missingKeys: missing,
+  };
+});
+
+console.log('▼ IndexedDB から読み出したレコード一覧');
+console.table(
+  stored.map((record) => ({
+    streamId: record.streamId,
+    teacherName: record.teacherName,
+    savedAt: record.savedAt,
+    attachmentCount: record.attachments.length,
+  })),
+);
+
+console.log('▼ 必須プロパティの検証結果');
+console.table(report);
+
+const everyRecordValid = report.every((row) => row.hasAllKeys);
+
+if (!everyRecordValid) {
+  console.error('❌ 必須プロパティが欠けているレコードがあります');
+  process.exitCode = 1;
+} else {
+  console.log('✅ すべてのレコードに必要なプロパティがそろっています');
+}

--- a/src/content.js
+++ b/src/content.js
@@ -237,8 +237,19 @@ function openStreamDB() {
   return request;
 }
 // openしたstoreにextractStreamData()をそのまま追加
-async function persistStreamData(root = document) {
-  const posts = extractStreamData(root);
+// 初心者向けポイント: options でテスト用データや現在時刻を差し替えられる
+async function persistStreamData(root = document, options = {}) {
+  const {
+    // presetPosts: テスト時などに生の配列を直接保存したいときの差し替え口
+    presetPosts = null,
+    // getNow: Date.now() を差し替えられるようにして保存時刻を固定できる
+    getNow = () => Date.now(),
+  } = options;
+
+  // presetPosts が配列ならそれを優先し、通常時は DOM から抽出
+  const posts = Array.isArray(presetPosts)
+    ? presetPosts
+    : extractStreamData(root);
   const request = openStreamDB();
 
   return new Promise((resolve, reject) => {
@@ -247,9 +258,22 @@ async function persistStreamData(root = document) {
       const db = request.result; //TODO:event.target.result;にリファクタしろ
       const tx = db.transaction(STREAM_STORE_NAME, "readwrite");
       const store = tx.objectStore(STREAM_STORE_NAME);
-      const savedAt = Date.now();
+      const savedAt = getNow();
       for (const post of posts) {
-        store.put({ ...post, savedAt });
+        // 初心者向けメモ: IndexedDB にはプレーンなオブジェクトしか入らない
+        // のでスプレッドでコピーしながら必須プロパティを補強しておく
+        const record = {
+          index: post.index ?? 0,
+          streamId: post.streamId ?? "",
+          teacherName: post.teacherName ?? "",
+          postedAt: post.postedAt ?? { text: "", datetime: "" },
+          body: post.body ?? "",
+          attachments: Array.isArray(post.attachments)
+            ? post.attachments
+            : [],
+          savedAt,
+        };
+        store.put(record);
       }
       tx.oncomplete = () => {
         db.close();
@@ -685,6 +709,7 @@ if (document.readyState === "loading") {
 if (typeof window !== "undefined") {
   window.__gcxDebug = {
     extractStreamData,
+    persistStreamData,
     loadStreamPostsFromDb,
     syncStreamPosts,
     getFuse: () => fuse,


### PR DESCRIPTION
## 概要
- indexedDBへ保存する際のプロパティを固定化するため、`persistStreamData`にオプションとバリデーションを追加
- デバッグ用APIに`persistStreamData`を公開して外部スクリプトから利用できるように修正
- Node.js上で保存内容を検証できる`scripts/validate-indexeddb.mjs`と`npm run check:db`スクリプトを追加

## テスト
- npm run check:db

------
https://chatgpt.com/codex/tasks/task_e_68d92c11fc98832cbd5f7dbc78a86912