### PR TITLE
fix: ストリーム同期を修正してサジェストを復旧

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -272,10 +272,16 @@ function normalizeWhitespace(value) {
     .trim();
 }
 //extractStreamDataからindex streamId + elementを返す（配列 > オブジェ。）
+// Classroom 側の DOM 変更に負けないよう、確実に投稿本体を拾うためのセレクタ
+// 1. data-stream-item-id を最優先で探す（公式属性）
+// 2. data-item-id + jsmodel でも拾えるように広げておく（UI 改修の保険）
 const STREAM_SELECTOR_PRIMARY =
-  'div[jscontroller="h38nBf"][data-stream-item-id], div[jscontroller="dk8rTb"][data-stream-item-id]';
+  '[data-stream-item-id], [data-item-id][jsmodel*="N2jS6b"]';
+// 3. それでも見つからない場合は記事（article / c-wiz）単位で拾ってフォールバック
 const STREAM_SELECTOR_FALLBACK =
-  'div[data-stream-item-id][jsmodel*="N2jS6b"], article[data-stream-item-id][jsmodel*="N2jS6b"]';
+  'c-wiz[jsmodel*="N2jS6b"], article[jsmodel*="N2jS6b"], li[jsmodel*="N2jS6b"]';
+// data-stream-item-id or data-item-id をまとめて探す共通セレクタ
+const STREAM_ID_SELECTOR = '[data-stream-item-id], [data-item-id]';
 
 let domFallbackLogged = false; // 初心者向けメモ: 同じ警告を何度も出さないためのフラグ
 let idFallbackLogged = false;
@@ -299,24 +305,39 @@ function collectStreamElements(root = document) {
     elements = fallback;
   }
 
-  const unique = new Map();
+  const seenIds = new Set();
+  const results = [];
+
   for (const element of elements) {
-    const streamId =
-      element.dataset?.streamItemId ||
-      element.getAttribute?.("data-stream-item-id") ||
-      element.getAttribute?.("data-item-id") ||
+    const idCarrier = element.matches(STREAM_ID_SELECTOR)
+      ? element
+      : element.querySelector(STREAM_ID_SELECTOR);
+    // 初心者向けメモ: idCarrier は「ID 属性を実際に持っている子要素」。
+    // 投稿カードそのものに data-stream-item-id が無い場合でも、
+    // 内側の子要素から拾ってユニーク ID を復元するために使うよ。
+    const rawId =
+      idCarrier?.dataset?.streamItemId ||
+      idCarrier?.getAttribute?.("data-stream-item-id") ||
+      idCarrier?.dataset?.itemId ||
+      idCarrier?.getAttribute?.("data-item-id") ||
       "";
-    if (!streamId) continue;
-    if (!unique.has(streamId)) {
-      unique.set(streamId, element);
+
+    if (rawId) {
+      if (seenIds.has(rawId)) {
+        continue;
+      }
+      seenIds.add(rawId);
     }
+
+    results.push({
+      // index: 1 から始まる連番。hashString の種にも使うので安定していると嬉しい。
+      index: results.length + 1,
+      streamId: rawId || null,
+      element,
+    });
   }
 
-  return Array.from(unique.entries()).map(([streamId, element], index) => ({
-    index: index + 1,
-    streamId,
-    element,
-  }));
+  return results;
 }
 
 // DOM から ID が取れない場合の保険。投稿の先生名/日時/本文からハッシュを作る。
@@ -328,11 +349,22 @@ function deriveStreamId({
   postedAt,
   bodyText,
 }) {
+  const descendantCarrier =
+    element?.matches?.(STREAM_ID_SELECTOR)
+      ? element
+      : element?.querySelector?.(STREAM_ID_SELECTOR);
+  // 初心者向けメモ: descendantCarrier は「子孫にある ID 持ちの要素」。
+  // directId を探すときに最後の切り札として使うイメージ。
   const directId =
     fallbackId ||
     element?.dataset?.streamItemId ||
     element?.getAttribute?.("data-stream-item-id") ||
+    element?.dataset?.itemId ||
     element?.getAttribute?.("data-item-id") ||
+    descendantCarrier?.dataset?.streamItemId ||
+    descendantCarrier?.getAttribute?.("data-stream-item-id") ||
+    descendantCarrier?.dataset?.itemId ||
+    descendantCarrier?.getAttribute?.("data-item-id") ||
     element?.id;
 
   if (directId) return directId;
@@ -395,6 +427,10 @@ async function persistStreamData(rootOrPosts = document) {
       const store = tx.objectStore(STREAM_STORE_NAME);
       const savedAt = Date.now();
       for (const post of posts) {
+        if (!post.streamId) {
+          console.warn("[GCX] skip store: missing streamId", post);
+          continue;
+        }
         store.put({ ...post, savedAt });
       }
       tx.oncomplete = () => {
@@ -441,8 +477,17 @@ async function loadStreamPostsFromDb() {
 
 // ２つのオブジェが違うかどうか、違うならtrue
 function findNewPosts(oldList, newList) {
-  const known = new Set(oldList.map((p) => p.streamId));
-  return newList.filter((post) => post.streamId && !known.has(post.streamId));
+  const known = new Set(
+    oldList
+      .map((p) => p.streamId)
+      .filter((id) => typeof id === "string" && id.length > 0)
+  );
+  return newList.filter((post) => {
+    if (!post.streamId) {
+      return true; // ID を付与できなかったら一旦保存候補にする
+    }
+    return !known.has(post.streamId);
+  });
 }
 
 let syncInFlight = false;


### PR DESCRIPTION
## 概要
- Classroom ストリーム投稿の収集セレクタを最新 DOM に追従させ、ID 取得を多段でフォールバック
- IndexedDB へ保存する際の ID 欠落時ガードと差分検出ロジックを強化
- DOM 変化時でもハッシュ生成が安定するようコメントと初心者向けの補足を追加

## テスト
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68d950490d60832ca3137a82fb676cb3