### PR TITLE
fix: ページコンテキスト経由でストリームHTMLを取得

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -90,7 +90,7 @@ function ensurePageBridge() {
   document.documentElement.appendChild(script);
 }
 
-function requestStreamDomFromPage(timeoutMs = 2000) {
+function requestStreamHtmlFromPage(mode = "context", timeoutMs = 2000) {
   ensurePageBridge();
   return new Promise((resolve) => {
     const requestId = `gcx-${Date.now().toString(36)}-${Math.random()
@@ -106,27 +106,34 @@ function requestStreamDomFromPage(timeoutMs = 2000) {
 
     const timer = setTimeout(() => {
       cleanup();
-      resolve(null);
+      resolve([]);
     }, timeoutMs);
 
     function handler(event) {
       if (event.source !== window) return;
       const data = event.data;
       if (!data || typeof data !== "object") return;
-      if (data.type !== "GCX_STREAM_DOM") return;
+      if (data.type !== "GCX_STREAM_DATA") return;
       if (data.requestId !== requestId) return;
+      if (data.mode !== mode) return;
 
       clearTimeout(timer);
       cleanup();
-      resolve(Array.isArray(data.payload) ? data.payload : []);
+      const payload = data.payload;
+      const list =
+        payload && typeof payload === "object" && Array.isArray(payload.html)
+          ? payload.html
+          : [];
+      resolve(list);
     }
 
     window.addEventListener("message", handler);
 
     window.postMessage(
       {
-        type: "GCX_REQUEST_STREAM_DOM",
+        type: "GCX_REQUEST_STREAM_DATA",
         requestId,
+        mode,
       },
       "*"
     );
@@ -134,9 +141,12 @@ function requestStreamDomFromPage(timeoutMs = 2000) {
 }
 
 async function collectPostsFromPageContext(root = document) {
-  let htmlList = null;
+  let htmlList = [];
   try {
-    htmlList = await requestStreamDomFromPage();
+    htmlList = await requestStreamHtmlFromPage("context");
+    if (!htmlList.length) {
+      htmlList = await requestStreamHtmlFromPage("dom");
+    }
   } catch (error) {
     console.warn("[GCX] page bridge request failed", error);
   }
@@ -621,11 +631,7 @@ async function syncStreamPosts(root = document) {
     ]);
 
     if (!currentPosts.length) {
-      return; //投稿が描画されるまで保存を触らない。
-    }
-
-    if (!currentPosts.length) {
-      return;
+      return; // 投稿が描画されるまで保存を触らない。
     }
     const newPosts = findNewPosts(savedPosts, currentPosts);
     if (newPosts.length) {
@@ -640,9 +646,6 @@ async function syncStreamPosts(root = document) {
     syncInFlight = false;
   }
 }
-
-// 後方互換用の別名（古いコードが小文字関数名を呼ぶ場合のため）
-const ensurestyle = ensureStyles;
 
 // ===== ローカル配布ライブラリ ローダー =====
 const LIB_SPECS = {

--- a/src/page-bridge.js
+++ b/src/page-bridge.js
@@ -2,7 +2,7 @@
   if (window.__gcxPageBridgeInstalled) return;
   window.__gcxPageBridgeInstalled = true;
 
-  function collectStreamHtml() {
+  function collectStreamDomHtml() {
     const selectors = [
       'div[jscontroller="h38nBf"][data-stream-item-id]',
       'div[jscontroller="dk8rTb"][data-stream-item-id]',
@@ -19,18 +19,73 @@
     return Array.from(nodes).map((node) => node.outerHTML);
   }
 
+  function collectStreamHtmlFromContext() {
+    const context = window.pageContext;
+    if (!context || typeof context !== "object") {
+      return [];
+    }
+
+    const seenObjects = new Set();
+    const htmlSet = new Set();
+    const stack = [context];
+
+    while (stack.length) {
+      const current = stack.pop();
+      if (current == null) continue;
+      const type = typeof current;
+      if (type === "string") {
+        if (current.includes("data-stream-item-id")) {
+          htmlSet.add(current);
+        }
+        continue;
+      }
+      if (type !== "object") continue;
+      if (seenObjects.has(current)) continue;
+      seenObjects.add(current);
+
+      if (Array.isArray(current)) {
+        for (let i = 0; i < current.length; i += 1) {
+          stack.push(current[i]);
+        }
+        continue;
+      }
+
+      const values = Object.values(current);
+      for (let i = 0; i < values.length; i += 1) {
+        const value = values[i];
+        if (value == null) continue;
+        const valueType = typeof value;
+        if (valueType === "string") {
+          if (value.includes("data-stream-item-id")) {
+            htmlSet.add(value);
+          }
+          continue;
+        }
+        if (valueType === "object") {
+          stack.push(value);
+        }
+      }
+    }
+
+    return Array.from(htmlSet);
+  }
+
   window.addEventListener("message", (event) => {
     if (event.source !== window) return;
     const data = event.data;
     if (!data || typeof data !== "object") return;
-    if (data.type !== "GCX_REQUEST_STREAM_DOM") return;
+    if (data.type !== "GCX_REQUEST_STREAM_DATA") return;
+    const mode = data.mode === "context" ? "context" : "dom";
 
-    const payload = collectStreamHtml();
+    const htmlList =
+      mode === "context" ? collectStreamHtmlFromContext() : collectStreamDomHtml();
+
     window.postMessage(
       {
-        type: "GCX_STREAM_DOM",
+        type: "GCX_STREAM_DATA",
         requestId: data.requestId,
-        payload,
+        mode,
+        payload: { html: Array.isArray(htmlList) ? htmlList : [] },
       },
       "*"
     );


### PR DESCRIPTION
## 概要
- pageContext 内のデータを再帰的に走査し、ストリーム投稿の HTML を抽出するブリッジを追加
- コンテンツスクリプト側で pageContext と DOM の両方を試す取得フローに刷新し、失敗時は自動フォールバック
- 使われていない互換コードと冗長な条件分岐を整理

## テスト
- 未実行（ローカル環境では Classroom 本番 DOM を再現できないため）

------
https://chatgpt.com/codex/tasks/task_e_68d9f498b2b4832c8e3fd30aeef04503