### PR TITLE
検索結果の上限設定とFuse検索テストの追加

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -11,6 +11,7 @@ const TOPBAR_WRAP = "gcx-topbar"; // 検索 UI ラッパーのクラス
 const TOPBAR_INPUT = "gcx-topbar-input"; // 検索入力のクラス
 const TOPBAR_ID = "gcx-topbar-overlay"; // DOM 上の ID（重複防止）
 const EXPANDED_CLASS = "is-expanded";
+const SUGGESTION_LIMIT = 20; // 初心者メモ: Fuse.js の検索結果は 20 件までに抑えておく
 const SVG_NS = "http://www.w3.org/2000/svg";
 const ICON_PATH_DATA = [
   "M172.625,102.4c-42.674,0-77.392,34.739-77.392,77.438c0,5.932,4.806,10.74,10.733,10.74c5.928,0,10.733-4.808,10.733-10.74c0-30.856,25.088-55.959,55.926-55.959c5.928,0,10.733-4.808,10.733-10.74C183.358,107.208,178.553,102.4,172.625,102.4z",
@@ -1006,16 +1007,28 @@ async function initFuse() {
   }
 }
 
+// 実際に Fuse.js へ問い合わせて「何件返すか」を決める係の小さな関数
+function collectTopMatches(query) {
+  // 入力が空文字だったり、まだ Fuse の準備が出来ていない場合は即終了
+  if (!query || !fuse) {
+    return [];
+  }
+
+  const safeQuery = query.trim();
+  if (!safeQuery) {
+    return [];
+  }
+
+  // limit オプションを付けると Fuse 側で件数を絞り込んでくれるよ
+  const results = fuse.search(safeQuery, { limit: SUGGESTION_LIMIT });
+  return results.map((entry) => entry.item);
+}
+
 //ユーザーからの入力をfuseのsearchにかけている。返り値は{item,score,refindex,...}
 function onSerchInput(event) {
   const query = event.target.value.trim();
   lastQuery = query;
-  if (!query || !fuse) {
-    renderSuggestions([]);
-    return;
-  }
-  const results = fuse.search(query);
-  renderSuggestions(results.map((item) => item.item)); //{item,score,refindex,...}
+  renderSuggestions(collectTopMatches(query));
 }
 //　ヒットしたfuseのうちitemをliに入れる。fragmentで一括で入れている。。
 function renderSuggestions(items) {
@@ -1063,9 +1076,10 @@ function renderSuggestions(items) {
 
 // IndexedDB からの差分同期後に、最後に入力したクエリで再検索するためのヘルパー
 function rerunLastQuery() {
-  if (!lastQuery || !fuse) return;
-  const results = fuse.search(lastQuery);
-  renderSuggestions(results.map((item) => item.item));
+  if (!lastQuery || !fuse) {
+    return;
+  }
+  renderSuggestions(collectTopMatches(lastQuery));
 }
 
 async function init() {
@@ -1094,6 +1108,7 @@ if (typeof window !== "undefined") {
     loadStreamPostsFromDb,
     syncStreamPosts,
     getFuse: () => fuse,
+    runSearchPreview: (query) => collectTopMatches(query),
   };
 }
 

--- a/tests/search.test.js
+++ b/tests/search.test.js
@@ -1,0 +1,74 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import Fuse from '../src/libs/fuse.esm.js';
+
+// content.js と同じ Fuse 設定をここでも再現
+const fuseOptions = {
+  includeMatches: true,
+  includeScore: true,
+  shouldSort: true,
+  threshold: 0.3,
+  keys: [
+    { name: 'teacherName', weight: 0.4 },
+    { name: 'body', weight: 0.4 },
+    { name: 'attachments.title', weight: 0.2 },
+    { name: 'postedAt.text', weight: 0.05 },
+  ],
+  minMatchCharLength: 1,
+};
+
+// テスト用の仮データ（実際の IndexedDB のレコードを真似ている）
+const samplePosts = [
+  {
+    streamId: 'post-1',
+    teacherName: '山田 太郎',
+    body: '次回の数学テスト範囲は p.30 〜 p.45 です。',
+    attachments: [{ title: '数学プリント.pdf' }],
+    postedAt: { text: '2024年5月1日' },
+  },
+  {
+    streamId: 'post-2',
+    teacherName: '佐藤 花子',
+    body: '体育祭のリハーサル時間割を共有します。',
+    attachments: [{ title: '体育祭タイムテーブル.xlsx' }],
+    postedAt: { text: '2024年5月2日' },
+  },
+  {
+    streamId: 'post-3',
+    teacherName: '田中 一郎',
+    body: '英語の小テスト答案を返却しました。',
+    attachments: [{ title: '英語課題.docx' }],
+    postedAt: { text: '2024年5月3日' },
+  },
+];
+
+test('本文のキーワードでヒットする', () => {
+  const fuse = new Fuse(samplePosts, fuseOptions);
+  const results = fuse.search('数学', { limit: 20 });
+  assert.equal(results[0].item.streamId, 'post-1');
+});
+
+test('先生の名前でも検索できる', () => {
+  const fuse = new Fuse(samplePosts, fuseOptions);
+  const results = fuse.search('佐藤', { limit: 20 });
+  assert.equal(results[0].item.streamId, 'post-2');
+});
+
+test('添付ファイル名からも引っ張れる', () => {
+  const fuse = new Fuse(samplePosts, fuseOptions);
+  const results = fuse.search('タイムテーブル', { limit: 20 });
+  assert.equal(results[0].item.streamId, 'post-2');
+});
+
+test('結果は 20 件までに制限される', () => {
+  const manyPosts = Array.from({ length: 35 }, (_, index) => ({
+    streamId: `bulk-${index}`,
+    teacherName: 'テスト 先生',
+    body: 'これは課題のサンプル本文です。',
+    attachments: [{ title: '課題資料.pdf' }],
+    postedAt: { text: '2024年5月4日' },
+  }));
+  const fuse = new Fuse(manyPosts, fuseOptions);
+  const results = fuse.search('課題', { limit: 20 });
+  assert.equal(results.length, 20);
+});


### PR DESCRIPTION
## 概要
- クイック検索用の Fuse.js を 20 件までに制限するヘルパーを追加し、再検索処理も同じ経路に統一
- 検索キーワード・先生名・添付ファイル名でのヒット確認と上限件数の確認を行う Node テストを追加

## テスト
- node --test tests/search.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d9ffe776ec832ca26aa3b9bbbb39ef